### PR TITLE
Make python package installable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+# These are the assumed default build requirements from pip:
+# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+import os
+
+from setuptools import find_packages
+from setuptools import setup
+
+
+# Utility function to read the README file.
+# Used for the long_description.  It's nice, because now 1) we have a top level
+# README file and 2) it's easier to type in the README file than to put a raw
+# string in below ...
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+def get_requirements(req_file):
+    """Read requirements file and return packages and git repos separately"""
+    requirements = []
+    dependency_links = []
+    lines = read(req_file).split("\n")
+    for line in lines:
+        if line.startswith("git+"):
+            dependency_links.append(line)
+        else:
+            requirements.append(line)
+    return requirements, dependency_links
+
+
+REQ_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "")
+core_reqs, core_dependency_links = get_requirements(
+    os.path.join(REQ_DIR, "requirements.txt")
+)
+dev_extras = read(os.path.join(REQ_DIR, "dev_requirements.txt")).split("\n")
+tests_require = ["pytest", "flake8"]
+
+
+setup(
+    name="cast",
+    version="0.1.0",
+    author="Héricles Emanuel",
+    description=("An instance of your terminal in your browswe"),
+    license="Apache-2.0",
+    keywords=("shell terminal browser" "web web-shell"),
+    packages=find_packages(exclude=["docs", "examples", "dist"]),
+    include_package_data=True,
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
+    url="https://github.com/tunl/cast-sh",
+    install_requires=core_reqs,
+    extras_require={
+        "dev": dev_extras,
+    },
+    dependency_links=core_dependency_links,
+    setup_requires=["pytest-runner"],
+    tests_require=tests_require,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+)


### PR DESCRIPTION
Make python package installable via pip.

## Description
Make it possible to build the package locally:
`pip install .`


## Fixes issue #104 

## Motivation and Context

## How Has This Been Tested?
- [x] Build package locally
- [x] Remove local files or get out of the directory
- [x] Start application

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/9937551/97783439-8ff1a000-1b76-11eb-84c7-87144221b775.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
