### PR TITLE
Add cli command to quickstart app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ To start the terminal cast application, run:
 python3 -m cast
 ```
 
+Or if you install the application via pip:
+```
+pip install .
+
+# command available once pkg has been installed
+cast-sh
+```
 
 #### Arguments
 ```

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     },
     dependency_links=core_dependency_links,
     setup_requires=["pytest-runner"],
+    entry_points={"console_scripts": ["cast-sh=cast.__main__:main"]},
     tests_require=tests_require,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Now once the package is installed, we can raise the application via the command `cast-sh`

## Fixes #106 

## How Has This Been Tested?
- [ ] Ran our included tests
- [x] Manual QA
- [ ] New test written

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9937551/97784105-da751b80-1b7a-11eb-9ef4-e9bf7f443075.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
