### PR TITLE
Replace return response for wrong password.

### DIFF
--- a/cast/routes.py
+++ b/cast/routes.py
@@ -58,7 +58,7 @@ def login():
             set_access_cookies(resp, access_token)
             return resp
         else:
-            return json.dumps(request.get_json()), 401
+            return jsonify({"message": "Wrong password."}), 401
 
 
 # This is the route handler for DOWNLOADING the log file. Maybe a bit buggy. Please report if found


### PR DESCRIPTION
`LGTM` reported a XSS vulnerability for `return json.dumps(request.get_json())`.
As returning the password given by the user in a XHR response has no particular purpose, it can be replaced by a standard message.

## Description
When the password provided by the user is wrong, the server no longer returns the password field value in the XHR response body but returns a regular "Wrong password." message.

## Fixes issue \#
#114 

## Motivation and Context
The previous combo `json.dumps()` + user provided string can indeed be used for XSS.
Although I'm not sure in this case how a malicious code could be used since the response would not be included in the DOM, thus never possibly executed.
I guess better safe than sorry :wink:

## How Has This Been Tested?
- [x] Ran our included tests
- [x] Manual QA
- [ ] New test written

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
